### PR TITLE
Add script to count profile usage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,5 @@ fabric.properties
 .idea
 
 out/
+
+.vscode

--- a/project_profile_counter.py
+++ b/project_profile_counter.py
@@ -6,23 +6,23 @@ SERVER = 'https://tokyo.sdelements.com'
 API_TOKEN = 'f258c47557a3f98f55d4fbd0cb9d8354c86fbb52'
 PROJECTS_URL = '{server}/api/v2/projects/?page_size=100'.format(server=SERVER)
 REQUESTS_HEADER = {
-    'Authorization': "Token " + API_TOKEN,   # Authorization header + generated API TOKEN
+    # Authorization header + generated API TOKEN
+    'Authorization': "Token " + API_TOKEN,
     'Accept': "application/json"             # Accepts API response in JSON format
 }
-
 url = PROJECTS_URL
 profiles = []
+
 while True:
-    response = requests.get(url, headers=REQUESTS_HEADER) 
+    response = requests.get(url, headers=REQUESTS_HEADER)
     data = response.json()
-
-    for item in data['results']:    # loop through the values in the results key 
-        profiles.append(item['profile']['name'])    # add each profile's name to list
-
-    if data["next"]:    # check if a value is present in "next" 
+# Fetches all the profile names(including duplicates) stored in the API response
+    profiles += [project['profile']['name'] for project in data['results']]
+# Grab the URL of the next page of results to fetch; if this entry is blank we have reached the last page
+    if data["next"]:
         url = data["next"]
     else:
-        break   # leave the infinite loop if your on the last page
-
-for profile, count in collections.Counter(profiles).items():    # count the profile occurences  
+        break
+for profile, count in collections.Counter(profiles).items():
+# Counts the number of times each profile occurs in the list using Python's collection's module
     print(u"{} : {}".format(profile, count))

--- a/project_profile_counter.py
+++ b/project_profile_counter.py
@@ -1,28 +1,34 @@
-import json
-import requests
 import collections
+import os
 
-SERVER = 'https://tokyo.sdelements.com'
-API_TOKEN = 'f258c47557a3f98f55d4fbd0cb9d8354c86fbb52'
+import requests
+
+
+SERVER = os.environ['SDE_SERVER']         # e.g. https://cd.sdelements.com
+API_TOKEN = os.environ['SDE_API_TOKEN']   # e.g. f258c47557a3f98f55d4fbd0cb9d8354c86fbb52
+
 PROJECTS_URL = '{server}/api/v2/projects/?page_size=100'.format(server=SERVER)
 REQUESTS_HEADER = {
-    # Authorization header + generated API TOKEN
-    'Authorization': "Token " + API_TOKEN,
-    'Accept': "application/json"             # Accepts API response in JSON format
+    'Authorization': "Token " + API_TOKEN,  # Authorization header + generated API TOKEN
+    'Accept': "application/json"
 }
+
 url = PROJECTS_URL
 profiles = []
-
 while True:
     response = requests.get(url, headers=REQUESTS_HEADER)
     data = response.json()
-# Fetches all the profile names(including duplicates) stored in the API response
+    
+    # Extract all the profile names stored in the API response
     profiles += [project['profile']['name'] for project in data['results']]
-# Grab the URL of the next page of results to fetch; if this entry is blank we have reached the last page
+    
+    # Grab the URL of the next page of results to fetch; if this entry is 
+    # blank we have reached the last page
     if data["next"]:
         url = data["next"]
     else:
         break
+
+# Count the number of profiles we previously found via the API.
 for profile, count in collections.Counter(profiles).items():
-# Counts the number of times each profile occurs in the list using Python's collection's module
     print(u"{} : {}".format(profile, count))

--- a/project_profile_counter.py
+++ b/project_profile_counter.py
@@ -5,13 +5,16 @@ import requests
 
 
 SERVER = os.environ['SDE_SERVER']         # e.g. https://cd.sdelements.com
-API_TOKEN = os.environ['SDE_API_TOKEN']   # e.g. f258c47557a3f98f55d4fbd0cb9d8354c86fbb52
+API_TOKEN = os.environ['SDE_API_TOKEN']   # e.g. f258c47557a3f98f55d4fbd0icb9d8354c86fbb52
 
 PROJECTS_URL = '{server}/api/v2/projects/?page_size=100'.format(server=SERVER)
 REQUESTS_HEADER = {
     'Authorization': "Token " + API_TOKEN,  # Authorization header + generated API TOKEN
     'Accept': "application/json"
 }
+
+print("Fetching projects from: {}".format(PROJECTS_URL))
+print("Using API Token: {}...".format(API_TOKEN[:5]))
 
 url = PROJECTS_URL
 profiles = []
@@ -21,7 +24,7 @@ while True:
     
     # Extract all the profile names stored in the API response
     profiles += [project['profile']['name'] for project in data['results']]
-    
+
     # Grab the URL of the next page of results to fetch; if this entry is 
     # blank we have reached the last page
     if data["next"]:

--- a/project_profile_counter.py
+++ b/project_profile_counter.py
@@ -1,0 +1,28 @@
+import json
+import requests
+import collections
+
+SERVER = 'https://tokyo.sdelements.com'
+API_TOKEN = 'f258c47557a3f98f55d4fbd0cb9d8354c86fbb52'
+PROJECTS_URL = '{server}/api/v2/projects/?page_size=100'.format(server=SERVER)
+REQUESTS_HEADER = {
+    'Authorization': "Token " + API_TOKEN,   # Authorization header + generated API TOKEN
+    'Accept': "application/json"             # Accepts API response in JSON format
+}
+
+url = PROJECTS_URL
+profiles = []
+while True:
+    response = requests.get(url, headers=REQUESTS_HEADER) 
+    data = response.json()
+
+    for item in data['results']:    # loop through the values in the results key 
+        profiles.append(item['profile']['name'])    # add each profile's name to list
+
+    if data["next"]:    # check if a value is present in "next" 
+        url = data["next"]
+    else:
+        break   # leave the infinite loop if your on the last page
+
+for profile, count in collections.Counter(profiles).items():    # count the profile occurences  
+    print(u"{} : {}".format(profile, count))


### PR DESCRIPTION
Fetch projects via the API and count the usage of each profile. Using the projects endpoint, this script requests projects(paginated) then adds each occurrence of profiles. It then displays a final list consisting of the profile name and the total count of this profile occurrence. 